### PR TITLE
feat: add automatic cargo publish after verified master release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,3 +164,20 @@ jobs:
           else
             gh release create "$TAG" dist/* --verify-tag --generate-notes --title "$TAG"
           fi
+
+  cargo-publish:
+    needs: [prepare, publish]
+    if: needs.prepare.outputs.skip == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.tag }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: cargo-publish
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked


### PR DESCRIPTION
## Summary

- Adds a `cargo-publish` job to `.github/workflows/release.yml` that publishes the crate to crates.io after a successful release
- The job is the last step in the pipeline: it depends on `prepare` (version bump + tag) **and** `publish` (GitHub release artifacts), so it only runs when all previous steps succeed
- Inherits the existing security guard in `prepare` — the workflow only triggers when CI ran on a **push to master** (`workflow_run.event == 'push' && head_branch == 'master'`), never on a PR targeting master

## Security design

The key condition preventing accidental publish on unmerged code lives in the `prepare` job's `if`:

```yaml
github.event.workflow_run.event == 'push' &&
github.event.workflow_run.head_branch == 'master'
```

`workflow_run.event` is `pull_request` for a PR and `push` only once the commit is **on** master. `cargo-publish` is downstream of `prepare`, so it is structurally impossible for it to run on unmerged code.

Additional safeguards:
- Checks out the exact git tag (`needs.prepare.outputs.tag`), not `master` HEAD
- Uses `cargo publish --locked` to require a matching `Cargo.lock`
- Token is stored as `CARGO_REGISTRY_TOKEN` GitHub secret — never in source

## Setup required

Add the `CARGO_REGISTRY_TOKEN` secret to the repository (Settings → Secrets → Actions) with a crates.io API token that has publish rights for the `clck` crate.

## Test plan

- [ ] Confirm the `cargo-publish` job does **not** appear in a PR CI run (only `validate` runs)
- [ ] Confirm the job **does** appear after a merge to master triggers the Release workflow
- [ ] Verify `CARGO_REGISTRY_TOKEN` secret is configured before the first publish

https://claude.ai/code/session_01DVQymeYoiDuwaV7nzamYFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVQymeYoiDuwaV7nzamYFK)_