### PR TITLE
Fix confirmation prompts, config sound pre-selection, and macOS notifications

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,7 +231,18 @@ pub fn prompt_for_alarm(config: &Config) -> Result<ValidatedInteractiveAnswers> 
     let sound = if sound_names.is_empty() {
         SoundSetting::TerminalBell
     } else {
-        SoundSetting::System(Select::new("Alarm sound:", sound_names).prompt()?)
+        let default_sound = match &config.sound {
+            SoundSetting::System(saved) => sound_names
+                .iter()
+                .position(|name| name.eq_ignore_ascii_case(saved))
+                .unwrap_or(0),
+            _ => 0,
+        };
+        SoundSetting::System(
+            Select::new("Alarm sound:", sound_names)
+                .with_starting_cursor(default_sound)
+                .prompt()?,
+        )
     };
     let notification = Confirm::new("Show desktop notification?")
         .with_default(config.notification)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,10 +106,12 @@ fn run_direct_schedule(
         );
     };
 
+    let mut had_error = false;
     let candidate = loop {
         match schedule::parse_direct(&expression) {
             Ok(candidate) => break candidate,
             Err(error) => {
+                had_error = true;
                 writeln!(terminal.writer, "{error}")?;
                 write!(terminal.writer, "Enter another date and time: ")?;
                 terminal.writer.flush()?;
@@ -120,8 +122,16 @@ fn run_direct_schedule(
             }
         }
     };
-    if !cli::confirm_candidate(&candidate, &mut terminal.reader, &mut terminal.writer)? {
-        return Ok(());
+    if had_error {
+        if !cli::confirm_candidate(&candidate, &mut terminal.reader, &mut terminal.writer)? {
+            return Ok(());
+        }
+    } else {
+        writeln!(
+            terminal.writer,
+            "Starting alarm for {}.",
+            candidate.display_target()
+        )?;
     }
     drop(terminal);
     start_scheduled_alarm(candidate, effective, title)
@@ -144,9 +154,7 @@ fn run_text_schedule(effective: Config, title: Option<String>) -> Result<()> {
             }
             let selected = cli::select_candidate(&candidates, &mut reader, &mut writer)?;
             let candidate = candidates[selected].clone();
-            if !cli::confirm_candidate(&candidate, &mut reader, &mut writer)? {
-                return Ok(());
-            }
+            writeln!(writer, "Starting alarm for {}.", candidate.display_target())?;
             return start_scheduled_alarm(candidate, effective, title);
         }
     }
@@ -171,9 +179,11 @@ fn run_text_schedule(effective: Config, title: Option<String>) -> Result<()> {
     };
     let selected = cli::select_candidate(&candidates, &mut terminal.reader, &mut terminal.writer)?;
     let candidate = candidates[selected].clone();
-    if !cli::confirm_candidate(&candidate, &mut terminal.reader, &mut terminal.writer)? {
-        return Ok(());
-    }
+    writeln!(
+        terminal.writer,
+        "Starting alarm for {}.",
+        candidate.display_target()
+    )?;
     drop(terminal);
     start_scheduled_alarm(candidate, effective, title)
 }

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -8,6 +8,21 @@ pub fn notification_body(target: Option<&str>, title: Option<&str>) -> String {
     }
 }
 
+#[cfg(target_os = "macos")]
+pub fn notify_time_up(target: Option<&str>, title: Option<&str>) -> Result<()> {
+    let body = notification_body(target, title);
+    // Escape for AppleScript double-quoted string
+    let escaped = body.replace('\\', "\\\\").replace('"', "\\\"");
+    let script = format!("display notification \"{escaped}\" with title \"Alarm clock\"");
+    // osascript goes through the Automation subsystem, which is reliably
+    // allowed to post notifications from CLI tools without a bundle identity.
+    let _ = std::process::Command::new("osascript")
+        .args(["-e", &script])
+        .status();
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
 pub fn notify_time_up(target: Option<&str>, title: Option<&str>) -> Result<()> {
     notify_rust::Notification::new()
         .summary("Alarm clock")


### PR DESCRIPTION
## Summary

- **No more unnecessary "yes" prompts** — `clck at <time>` now starts immediately when the expression parses correctly on the first try. Confirmation only appears if you had to correct an invalid entry. Same for `from-text`: selecting a candidate is the confirmation.
- **Config sound preference now sticks** — the interactive alarm prompt was ignoring the saved sound setting (always starting the dropdown at index 0). It now pre-selects whichever sound was last saved.
- **macOS notifications fixed** — switched to `osascript` on macOS, which reliably delivers banners from CLI tools that lack a bundle identity. `notify-rust` is kept for Linux/Windows.

## Test plan

- [ ] `clck at "3pm"` (valid time) → starts without asking yes/no, prints "Starting alarm for ..."
- [ ] `clck at "notadate"` → shows error, prompts for correction, then confirms before starting
- [ ] `clck from-text` → paste text with a time → selects/starts without an extra confirm step
- [ ] Run interactive mode, pick a non-default sound, save → re-run interactive mode → saved sound is pre-selected
- [ ] On macOS: alarm fires → macOS notification banner appears in Notification Center

https://claude.ai/code/session_01Dyxo9dktdHTYiiNJBLsPjw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dyxo9dktdHTYiiNJBLsPjw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Alarm sound selector now preselects your previously saved choice
  * Direct schedule mode skips confirmation step when date/time parsing is successful
  * Text schedule mode streamlined to start alarms immediately after selection
  * Enhanced notification delivery on macOS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->