### PR TITLE
Add stopwatch subcommand for count-up time tracking

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -45,12 +45,7 @@ pub fn run_stopwatch(request: StopwatchRequest) -> Result<Duration> {
         let paused = watch.is_paused();
         let current_second = elapsed.as_secs();
         if displayed_second != Some(current_second) || paused != last_paused {
-            terminal.render_stopwatch(
-                elapsed,
-                &request.font,
-                request.title.as_deref(),
-                paused,
-            )?;
+            terminal.render_stopwatch(elapsed, &request.font, request.title.as_deref(), paused)?;
             displayed_second = Some(current_second);
             last_paused = paused;
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use crate::{
     audio::{AlarmPlayer, ResolvedSound},
     display::{DisplayEvent, TerminalSession},
     notification,
-    timer::Countdown,
+    timer::{Countdown, Stopwatch},
 };
 use anyhow::Result;
 use std::{
@@ -22,6 +22,58 @@ pub struct AlarmRequest {
     pub sound: ResolvedSound,
     pub notification: bool,
     pub target: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct StopwatchRequest {
+    pub title: Option<String>,
+    pub font: String,
+}
+
+pub fn run_stopwatch(request: StopwatchRequest) -> Result<Duration> {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let signal = Arc::clone(&cancelled);
+    ctrlc::set_handler(move || signal.store(true, Ordering::SeqCst))?;
+
+    let terminal = TerminalSession::enter()?;
+    let mut watch = Stopwatch::new(Instant::now());
+    let mut displayed_second = None;
+    let mut last_paused = false;
+    loop {
+        let now = Instant::now();
+        let elapsed = watch.elapsed(now);
+        let paused = watch.is_paused();
+        let current_second = elapsed.as_secs();
+        if displayed_second != Some(current_second) || paused != last_paused {
+            terminal.render_stopwatch(
+                elapsed,
+                &request.font,
+                request.title.as_deref(),
+                paused,
+            )?;
+            displayed_second = Some(current_second);
+            last_paused = paused;
+        }
+        if cancelled.load(Ordering::SeqCst) {
+            break;
+        }
+        match TerminalSession::next_event(Duration::from_millis(100), false)? {
+            DisplayEvent::Cancel => break,
+            DisplayEvent::Resize => displayed_second = None,
+            DisplayEvent::TogglePause => {
+                let now = Instant::now();
+                if watch.is_paused() {
+                    watch.resume(now);
+                } else {
+                    watch.pause(now);
+                }
+                displayed_second = None;
+            }
+            _ => {}
+        }
+    }
+    drop(terminal);
+    Ok(watch.elapsed(Instant::now()))
 }
 
 pub fn run_alarm(request: AlarmRequest) -> Result<()> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,7 @@ pub enum Command {
     },
     Fonts,
     Sounds,
+    Stopwatch,
 }
 
 pub struct ControllingTerminal {

--- a/src/display.rs
+++ b/src/display.rs
@@ -93,6 +93,31 @@ impl TerminalSession {
         render_lines(&lines, status.as_deref())
     }
 
+    pub fn render_stopwatch(
+        &self,
+        elapsed: Duration,
+        preferred_font: &str,
+        title: Option<&str>,
+        paused: bool,
+    ) -> Result<()> {
+        let (width, height) = terminal::size()?;
+        let text = format_elapsed(elapsed);
+        let catalog = FontCatalog::default();
+        let available = Size::new(width.saturating_sub(2), height.saturating_sub(4));
+        let lines = catalog
+            .largest_fit_preferring(preferred_font, &text, available)
+            .map(|font| font.render(&text))
+            .unwrap_or_else(|| vec![text]);
+
+        let status = stopwatch_status(title, paused);
+        let status = if status.chars().count() <= usize::from(width) {
+            Some(status)
+        } else {
+            None
+        };
+        render_lines(&lines, status.as_deref())
+    }
+
     pub fn render_ringing(&self, target: Option<&str>, title: Option<&str>) -> Result<()> {
         let status = match (title, target) {
             (Some(title), Some(target)) => {
@@ -138,6 +163,31 @@ pub fn format_duration(duration: Duration) -> String {
     }
 }
 
+pub fn format_elapsed(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    let hours = seconds / 3_600;
+    let minutes = (seconds % 3_600) / 60;
+    let secs = seconds % 60;
+    if hours > 0 {
+        format!("{hours:02}:{minutes:02}:{secs:02}")
+    } else {
+        format!("{minutes:02}:{secs:02}")
+    }
+}
+
+pub fn stopwatch_status(title: Option<&str>, paused: bool) -> String {
+    let mut parts = Vec::new();
+    if let Some(title) = title {
+        parts.push(format!("Title: {title}"));
+    }
+    if paused {
+        parts.push("PAUSED | Space to resume | q/Esc/Ctrl+C to stop".to_owned());
+    } else {
+        parts.push("Space to pause | q/Esc/Ctrl+C to stop".to_owned());
+    }
+    parts.join(" | ")
+}
+
 pub fn countdown_status(
     sound: &str,
     target: Option<&str>,
@@ -162,8 +212,9 @@ pub fn countdown_status(
 
 #[cfg(test)]
 mod tests {
-    use super::{countdown_status, event_from_key, DisplayEvent};
+    use super::{countdown_status, event_from_key, format_elapsed, stopwatch_status, DisplayEvent};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use std::time::Duration;
 
     #[test]
     fn maps_countdown_cancel_keys() {
@@ -182,6 +233,30 @@ mod tests {
         assert_eq!(
             event_from_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE), false),
             DisplayEvent::TogglePause
+        );
+    }
+
+    #[test]
+    fn format_elapsed_floors_to_whole_seconds() {
+        assert_eq!(format_elapsed(Duration::from_secs(0)), "00:00");
+        assert_eq!(format_elapsed(Duration::from_millis(999)), "00:00");
+        assert_eq!(format_elapsed(Duration::from_secs(65)), "01:05");
+        assert_eq!(format_elapsed(Duration::from_secs(3661)), "01:01:01");
+    }
+
+    #[test]
+    fn stopwatch_status_reflects_pause_state() {
+        assert_eq!(
+            stopwatch_status(None, false),
+            "Space to pause | q/Esc/Ctrl+C to stop"
+        );
+        assert_eq!(
+            stopwatch_status(None, true),
+            "PAUSED | Space to resume | q/Esc/Ctrl+C to stop"
+        );
+        assert_eq!(
+            stopwatch_status(Some("Build"), false),
+            "Title: Build | Space to pause | q/Esc/Ctrl+C to stop"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,14 @@ pub fn run() -> Result<()> {
                     println!("{name}: {}", path.display());
                 }
             }
+            cli::Command::Stopwatch => {
+                let elapsed = app::run_stopwatch(app::StopwatchRequest {
+                    title: cli.title,
+                    font: command_config.font,
+                })?;
+                println!("Elapsed: {}", display::format_elapsed(elapsed));
+                return Ok(());
+            }
             cli::Command::Config { show, reset } => {
                 if reset {
                     if Confirm::new("Reset saved clck settings?")

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -138,8 +138,14 @@ mod tests {
     fn stopwatch_counts_up() {
         let start = Instant::now();
         let watch = Stopwatch::new(start);
-        assert_eq!(watch.elapsed(start + Duration::from_secs(30)), Duration::from_secs(30));
-        assert_eq!(watch.elapsed(start + Duration::from_secs(90)), Duration::from_secs(90));
+        assert_eq!(
+            watch.elapsed(start + Duration::from_secs(30)),
+            Duration::from_secs(30)
+        );
+        assert_eq!(
+            watch.elapsed(start + Duration::from_secs(90)),
+            Duration::from_secs(90)
+        );
     }
 
     #[test]
@@ -149,7 +155,10 @@ mod tests {
         watch.pause(start + Duration::from_secs(10));
         assert!(watch.is_paused());
         // Elapsed should not advance while paused
-        assert_eq!(watch.elapsed(start + Duration::from_secs(30)), Duration::from_secs(10));
+        assert_eq!(
+            watch.elapsed(start + Duration::from_secs(30)),
+            Duration::from_secs(10)
+        );
     }
 
     #[test]
@@ -161,6 +170,9 @@ mod tests {
         watch.resume(resumed_at);
         assert!(!watch.is_paused());
         // 5 more seconds after resume → total elapsed = 10 + 5 = 15
-        assert_eq!(watch.elapsed(resumed_at + Duration::from_secs(5)), Duration::from_secs(15));
+        assert_eq!(
+            watch.elapsed(resumed_at + Duration::from_secs(5)),
+            Duration::from_secs(15)
+        );
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -48,9 +48,47 @@ impl Countdown {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct Stopwatch {
+    accumulated: Duration,
+    resumed_at: Option<Instant>,
+}
+
+impl Stopwatch {
+    pub fn new(started_at: Instant) -> Self {
+        Self {
+            accumulated: Duration::ZERO,
+            resumed_at: Some(started_at),
+        }
+    }
+
+    pub fn elapsed(&self, now: Instant) -> Duration {
+        self.accumulated
+            + self
+                .resumed_at
+                .map_or(Duration::ZERO, |t| now.duration_since(t))
+    }
+
+    pub fn pause(&mut self, now: Instant) {
+        if let Some(resumed_at) = self.resumed_at.take() {
+            self.accumulated += now.duration_since(resumed_at);
+        }
+    }
+
+    pub fn resume(&mut self, now: Instant) {
+        if self.resumed_at.is_none() {
+            self.resumed_at = Some(now);
+        }
+    }
+
+    pub fn is_paused(&self) -> bool {
+        self.resumed_at.is_none()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::Countdown;
+    use super::{Countdown, Stopwatch};
     use std::time::{Duration, Instant};
 
     #[test]
@@ -94,5 +132,35 @@ mod tests {
             timer.remaining(resumed_at + Duration::from_secs(5)),
             Duration::from_secs(45)
         );
+    }
+
+    #[test]
+    fn stopwatch_counts_up() {
+        let start = Instant::now();
+        let watch = Stopwatch::new(start);
+        assert_eq!(watch.elapsed(start + Duration::from_secs(30)), Duration::from_secs(30));
+        assert_eq!(watch.elapsed(start + Duration::from_secs(90)), Duration::from_secs(90));
+    }
+
+    #[test]
+    fn stopwatch_pause_freezes_elapsed() {
+        let start = Instant::now();
+        let mut watch = Stopwatch::new(start);
+        watch.pause(start + Duration::from_secs(10));
+        assert!(watch.is_paused());
+        // Elapsed should not advance while paused
+        assert_eq!(watch.elapsed(start + Duration::from_secs(30)), Duration::from_secs(10));
+    }
+
+    #[test]
+    fn stopwatch_resume_continues_accumulating() {
+        let start = Instant::now();
+        let mut watch = Stopwatch::new(start);
+        watch.pause(start + Duration::from_secs(10));
+        let resumed_at = start + Duration::from_secs(20);
+        watch.resume(resumed_at);
+        assert!(!watch.is_paused());
+        // 5 more seconds after resume → total elapsed = 10 + 5 = 15
+        assert_eq!(watch.elapsed(resumed_at + Duration::from_secs(5)), Duration::from_secs(15));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `clck stopwatch` subcommand that counts up from zero using the same ASCII-art font display as the countdown alarm
- Supports pause/resume with Space, and stops cleanly on `q` / `Esc` / `Ctrl-C` or an external `SIGINT`
- On exit, prints `Elapsed: MM:SS` (or `HH:MM:SS`) to stdout so scripts and hooks can capture it
- Optional `--title` label displayed in the status bar (inherits the existing global flag)

## Hook integration examples

**Claude Code hooks** — start the stopwatch before a tool runs, stop it after:
```json
{
  "hooks": {
    "PreToolUse":  [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "clck stopwatch --title 'Bash tool' &" }] }],
    "PostToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "pkill -INT -f 'clck stopwatch'" }] }]
  }
}
```

**Bash process monitoring** — stop the stopwatch when a watched process exits:
```bash
clck stopwatch --title "make build" &
SWPID=$!
make build
kill -INT $SWPID
wait $SWPID   # prints elapsed time
```

## Test plan

- [ ] `clck stopwatch` starts counting up in ASCII art, status bar shows `Space to pause | q/Esc/Ctrl+C to stop`
- [ ] Space pauses/resumes correctly
- [ ] `q`, `Esc`, `Ctrl-C` all exit and print `Elapsed: …` to the terminal
- [ ] `kill -INT <pid>` from another shell stops it and prints elapsed
- [ ] `--title "My task"` appears in the status bar
- [ ] `--font` flag selects a different ASCII font
- [ ] All 32 unit tests pass (`cargo test --no-default-features`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CXyekeRq6kKvL1A5Wyxviq

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXyekeRq6kKvL1A5Wyxviq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive stopwatch tool with pause/resume capabilities
  * Displays elapsed time in standard time format with optional activity titles
  * Supports terminal resizing and graceful cancellation via Ctrl-C

<!-- end of auto-generated comment: release notes by coderabbit.ai -->