### PR TITLE
Add stopwatch restart key, bare-hour scheduling, and UX improvements

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -46,14 +46,24 @@ pub fn run_stopwatch(request: StopwatchRequest) -> Result<Duration> {
         let paused = watch.is_paused();
         let current_second = elapsed.as_secs();
         if displayed_second != Some(current_second) || paused != last_paused {
-            terminal.render_stopwatch(elapsed, &request.font, request.title.as_deref(), paused, &request.restart_key)?;
+            terminal.render_stopwatch(
+                elapsed,
+                &request.font,
+                request.title.as_deref(),
+                paused,
+                &request.restart_key,
+            )?;
             displayed_second = Some(current_second);
             last_paused = paused;
         }
         if cancelled.load(Ordering::SeqCst) {
             break;
         }
-        match TerminalSession::next_event(Duration::from_millis(100), false, Some(&request.restart_key))? {
+        match TerminalSession::next_event(
+            Duration::from_millis(100),
+            false,
+            Some(&request.restart_key),
+        )? {
             DisplayEvent::Cancel => break,
             DisplayEvent::Resize => displayed_second = None,
             DisplayEvent::Restart => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,6 +28,7 @@ pub struct AlarmRequest {
 pub struct StopwatchRequest {
     pub title: Option<String>,
     pub font: String,
+    pub restart_key: String,
 }
 
 pub fn run_stopwatch(request: StopwatchRequest) -> Result<Duration> {
@@ -45,16 +46,21 @@ pub fn run_stopwatch(request: StopwatchRequest) -> Result<Duration> {
         let paused = watch.is_paused();
         let current_second = elapsed.as_secs();
         if displayed_second != Some(current_second) || paused != last_paused {
-            terminal.render_stopwatch(elapsed, &request.font, request.title.as_deref(), paused)?;
+            terminal.render_stopwatch(elapsed, &request.font, request.title.as_deref(), paused, &request.restart_key)?;
             displayed_second = Some(current_second);
             last_paused = paused;
         }
         if cancelled.load(Ordering::SeqCst) {
             break;
         }
-        match TerminalSession::next_event(Duration::from_millis(100), false)? {
+        match TerminalSession::next_event(Duration::from_millis(100), false, Some(&request.restart_key))? {
             DisplayEvent::Cancel => break,
             DisplayEvent::Resize => displayed_second = None,
+            DisplayEvent::Restart => {
+                let now = Instant::now();
+                watch = Stopwatch::new(now);
+                displayed_second = None;
+            }
             DisplayEvent::TogglePause => {
                 let now = Instant::now();
                 if watch.is_paused() {
@@ -103,7 +109,7 @@ pub fn run_alarm(request: AlarmRequest) -> Result<()> {
         if cancelled.load(Ordering::SeqCst) {
             return Ok(());
         }
-        match TerminalSession::next_event(Duration::from_millis(100), false)? {
+        match TerminalSession::next_event(Duration::from_millis(100), false, None)? {
             DisplayEvent::Cancel => return Ok(()),
             DisplayEvent::Resize => displayed_second = None,
             DisplayEvent::TogglePause => {
@@ -127,7 +133,7 @@ pub fn run_alarm(request: AlarmRequest) -> Result<()> {
     let mut last_bell = Instant::now();
     loop {
         if cancelled.load(Ordering::SeqCst)
-            || TerminalSession::next_event(Duration::from_millis(100), true)?
+            || TerminalSession::next_event(Duration::from_millis(100), true, None)?
                 == DisplayEvent::Dismiss
         {
             break;

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,7 @@ mod tests {
         assert_eq!(resolved.font, "banner");
         assert!(resolved.notification);
         assert_eq!(resolved.sound, SoundSetting::System("Glass".into()));
+        assert_eq!(resolved.restart_key, "r");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub struct Config {
     pub font: String,
     pub notification: bool,
     pub sound: SoundSetting,
+    pub restart_key: String,
 }
 
 impl Default for Config {
@@ -28,6 +29,7 @@ impl Default for Config {
             font: "standard".into(),
             notification: true,
             sound: SoundSetting::System("Glass".into()),
+            restart_key: "r".into(),
         }
     }
 }
@@ -79,6 +81,7 @@ impl Config {
             font: overrides.font.unwrap_or_else(|| self.font.clone()),
             notification: overrides.notification.unwrap_or(self.notification),
             sound: overrides.sound.unwrap_or_else(|| self.sound.clone()),
+            restart_key: self.restart_key.clone(),
         }
     }
 }
@@ -93,6 +96,7 @@ mod tests {
             font: "box".into(),
             notification: false,
             sound: SoundSetting::System("Glass".into()),
+            restart_key: "r".into(),
         };
         let resolved = saved.resolve(Overrides {
             font: Some("banner".into()),

--- a/src/display.rs
+++ b/src/display.rs
@@ -31,9 +31,13 @@ fn key_matches(key: KeyEvent, spec: &str) -> bool {
     } else {
         (KeyModifiers::NONE, spec)
     };
-    let Some(c) = ch_str.chars().next() else {
+    let mut chars = ch_str.chars();
+    let Some(c) = chars.next() else {
         return false;
     };
+    if chars.next().is_some() {
+        return false;
+    }
     key.code == KeyCode::Char(c) && key.modifiers == required_mods
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -22,11 +22,29 @@ pub enum DisplayEvent {
     Dismiss,
     Resize,
     TogglePause,
+    Restart,
 }
 
-pub fn event_from_key(key: KeyEvent, ringing: bool) -> DisplayEvent {
+fn key_matches(key: KeyEvent, spec: &str) -> bool {
+    let (required_mods, ch_str) = if let Some(rest) = spec.strip_prefix("ctrl+") {
+        (KeyModifiers::CONTROL, rest)
+    } else {
+        (KeyModifiers::NONE, spec)
+    };
+    let Some(c) = ch_str.chars().next() else {
+        return false;
+    };
+    key.code == KeyCode::Char(c) && key.modifiers == required_mods
+}
+
+pub fn event_from_key(key: KeyEvent, ringing: bool, restart_key: Option<&str>) -> DisplayEvent {
     if ringing {
         return DisplayEvent::Dismiss;
+    }
+    if let Some(rk) = restart_key {
+        if key_matches(key, rk) {
+            return DisplayEvent::Restart;
+        }
     }
     match key.code {
         KeyCode::Char('q') | KeyCode::Esc => DisplayEvent::Cancel,
@@ -45,12 +63,12 @@ impl TerminalSession {
         Ok(Self)
     }
 
-    pub fn next_event(timeout: Duration, ringing: bool) -> Result<DisplayEvent> {
+    pub fn next_event(timeout: Duration, ringing: bool, restart_key: Option<&str>) -> Result<DisplayEvent> {
         if !event::poll(timeout)? {
             return Ok(DisplayEvent::None);
         }
         Ok(match event::read()? {
-            Event::Key(key) => event_from_key(key, ringing),
+            Event::Key(key) => event_from_key(key, ringing, restart_key),
             Event::Resize(_, _) => DisplayEvent::Resize,
             _ => DisplayEvent::None,
         })
@@ -99,6 +117,7 @@ impl TerminalSession {
         preferred_font: &str,
         title: Option<&str>,
         paused: bool,
+        restart_key: &str,
     ) -> Result<()> {
         let (width, height) = terminal::size()?;
         let text = format_elapsed(elapsed);
@@ -109,7 +128,7 @@ impl TerminalSession {
             .map(|font| font.render(&text))
             .unwrap_or_else(|| vec![text]);
 
-        let status = stopwatch_status(title, paused);
+        let status = stopwatch_status(title, paused, restart_key);
         let status = if status.chars().count() <= usize::from(width) {
             Some(status)
         } else {
@@ -175,15 +194,19 @@ pub fn format_elapsed(duration: Duration) -> String {
     }
 }
 
-pub fn stopwatch_status(title: Option<&str>, paused: bool) -> String {
+pub fn stopwatch_status(title: Option<&str>, paused: bool, restart_key: &str) -> String {
     let mut parts = Vec::new();
     if let Some(title) = title {
         parts.push(format!("Title: {title}"));
     }
     if paused {
-        parts.push("PAUSED | Space to resume | q/Esc/Ctrl+C to stop".to_owned());
+        parts.push(format!(
+            "PAUSED | Space to resume | {restart_key} to restart | q/Esc/Ctrl+C to stop"
+        ));
     } else {
-        parts.push("Space to pause | q/Esc/Ctrl+C to stop".to_owned());
+        parts.push(format!(
+            "Space to pause | {restart_key} to restart | q/Esc/Ctrl+C to stop"
+        ));
     }
     parts.join(" | ")
 }
@@ -212,28 +235,68 @@ pub fn countdown_status(
 
 #[cfg(test)]
 mod tests {
-    use super::{countdown_status, event_from_key, format_elapsed, stopwatch_status, DisplayEvent};
+    use super::{countdown_status, event_from_key, format_elapsed, key_matches, stopwatch_status, DisplayEvent};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use std::time::Duration;
 
     #[test]
     fn maps_countdown_cancel_keys() {
         assert_eq!(
-            event_from_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), false),
+            event_from_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), false, None),
             DisplayEvent::Cancel
         );
         assert_eq!(
-            event_from_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), false),
+            event_from_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE), false, None),
             DisplayEvent::Cancel
         );
         assert_eq!(
-            event_from_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), true),
+            event_from_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), true, None),
             DisplayEvent::Dismiss
         );
         assert_eq!(
-            event_from_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE), false),
+            event_from_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE), false, None),
             DisplayEvent::TogglePause
         );
+    }
+
+    #[test]
+    fn restart_key_fires_restart_event() {
+        assert_eq!(
+            event_from_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE), false, Some("r")),
+            DisplayEvent::Restart
+        );
+        assert_eq!(
+            event_from_key(
+                KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
+                false,
+                Some("ctrl+r")
+            ),
+            DisplayEvent::Restart
+        );
+        assert_eq!(
+            event_from_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE), false, None),
+            DisplayEvent::None
+        );
+    }
+
+    #[test]
+    fn key_matches_plain_and_ctrl() {
+        assert!(key_matches(
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            "r"
+        ));
+        assert!(!key_matches(
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
+            "r"
+        ));
+        assert!(key_matches(
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
+            "ctrl+r"
+        ));
+        assert!(!key_matches(
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+            "ctrl+r"
+        ));
     }
 
     #[test]
@@ -247,16 +310,20 @@ mod tests {
     #[test]
     fn stopwatch_status_reflects_pause_state() {
         assert_eq!(
-            stopwatch_status(None, false),
-            "Space to pause | q/Esc/Ctrl+C to stop"
+            stopwatch_status(None, false, "r"),
+            "Space to pause | r to restart | q/Esc/Ctrl+C to stop"
         );
         assert_eq!(
-            stopwatch_status(None, true),
-            "PAUSED | Space to resume | q/Esc/Ctrl+C to stop"
+            stopwatch_status(None, true, "r"),
+            "PAUSED | Space to resume | r to restart | q/Esc/Ctrl+C to stop"
         );
         assert_eq!(
-            stopwatch_status(Some("Build"), false),
-            "Title: Build | Space to pause | q/Esc/Ctrl+C to stop"
+            stopwatch_status(Some("Build"), false, "r"),
+            "Title: Build | Space to pause | r to restart | q/Esc/Ctrl+C to stop"
+        );
+        assert_eq!(
+            stopwatch_status(None, false, "ctrl+r"),
+            "Space to pause | ctrl+r to restart | q/Esc/Ctrl+C to stop"
         );
     }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -63,7 +63,11 @@ impl TerminalSession {
         Ok(Self)
     }
 
-    pub fn next_event(timeout: Duration, ringing: bool, restart_key: Option<&str>) -> Result<DisplayEvent> {
+    pub fn next_event(
+        timeout: Duration,
+        ringing: bool,
+        restart_key: Option<&str>,
+    ) -> Result<DisplayEvent> {
         if !event::poll(timeout)? {
             return Ok(DisplayEvent::None);
         }
@@ -235,14 +239,21 @@ pub fn countdown_status(
 
 #[cfg(test)]
 mod tests {
-    use super::{countdown_status, event_from_key, format_elapsed, key_matches, stopwatch_status, DisplayEvent};
+    use super::{
+        countdown_status, event_from_key, format_elapsed, key_matches, stopwatch_status,
+        DisplayEvent,
+    };
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use std::time::Duration;
 
     #[test]
     fn maps_countdown_cancel_keys() {
         assert_eq!(
-            event_from_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), false, None),
+            event_from_key(
+                KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+                false,
+                None
+            ),
             DisplayEvent::Cancel
         );
         assert_eq!(
@@ -250,11 +261,19 @@ mod tests {
             DisplayEvent::Cancel
         );
         assert_eq!(
-            event_from_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), true, None),
+            event_from_key(
+                KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+                true,
+                None
+            ),
             DisplayEvent::Dismiss
         );
         assert_eq!(
-            event_from_key(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE), false, None),
+            event_from_key(
+                KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE),
+                false,
+                None
+            ),
             DisplayEvent::TogglePause
         );
     }
@@ -262,7 +281,11 @@ mod tests {
     #[test]
     fn restart_key_fires_restart_event() {
         assert_eq!(
-            event_from_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE), false, Some("r")),
+            event_from_key(
+                KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+                false,
+                Some("r")
+            ),
             DisplayEvent::Restart
         );
         assert_eq!(
@@ -274,7 +297,11 @@ mod tests {
             DisplayEvent::Restart
         );
         assert_eq!(
-            event_from_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE), false, None),
+            event_from_key(
+                KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE),
+                false,
+                None
+            ),
             DisplayEvent::None
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub fn run() -> Result<()> {
                 let elapsed = app::run_stopwatch(app::StopwatchRequest {
                     title: cli.title,
                     font: command_config.font,
+                    restart_key: command_config.restart_key.clone(),
                 })?;
                 println!("Elapsed: {}", display::format_elapsed(elapsed));
                 return Ok(());
@@ -90,6 +91,7 @@ pub fn run() -> Result<()> {
             font: answers.font,
             notification: answers.notification,
             sound: answers.sound,
+            restart_key: config.restart_key.clone(),
         };
         if answers.save_defaults {
             effective.save()?;
@@ -107,19 +109,13 @@ fn run_direct_schedule(
 ) -> Result<()> {
     let Some(mut terminal) = cli::open_controlling_terminal() else {
         let candidate = schedule::parse_direct(&expression)?;
-        bail!(
-            "confirmation is required before starting an alarm; detected candidate: {} -> {}",
-            candidate.source,
-            candidate.display_target()
-        );
+        return start_scheduled_alarm(candidate, effective, title);
     };
 
-    let mut had_error = false;
     let candidate = loop {
         match schedule::parse_direct(&expression) {
             Ok(candidate) => break candidate,
             Err(error) => {
-                had_error = true;
                 writeln!(terminal.writer, "{error}")?;
                 write!(terminal.writer, "Enter another date and time: ")?;
                 terminal.writer.flush()?;
@@ -130,17 +126,11 @@ fn run_direct_schedule(
             }
         }
     };
-    if had_error {
-        if !cli::confirm_candidate(&candidate, &mut terminal.reader, &mut terminal.writer)? {
-            return Ok(());
-        }
-    } else {
-        writeln!(
-            terminal.writer,
-            "Starting alarm for {}.",
-            candidate.display_target()
-        )?;
-    }
+    writeln!(
+        terminal.writer,
+        "Starting alarm for {}.",
+        candidate.display_target()
+    )?;
     drop(terminal);
     start_scheduled_alarm(candidate, effective, title)
 }

--- a/src/schedule.rs
+++ b/src/schedule.rs
@@ -25,9 +25,10 @@ impl Candidate {
 
     pub fn display_target(&self) -> String {
         format!(
-            "{} ({})",
-            self.target.format("%Y-%m-%d %H:%M:%S %:z"),
-            self.timezone
+            "{} ({} {})",
+            self.target.format("%Y-%m-%d %H:%M"),
+            self.timezone,
+            self.target.format("%:z")
         )
     }
 }
@@ -204,7 +205,12 @@ fn parse_time(input: &str) -> Option<NaiveTime> {
         (input, None)
     };
     if suffix.is_none() && !clock.contains(':') {
-        return None;
+        let hour: u32 = clock.parse().ok()?;
+        return if hour < 24 {
+            NaiveTime::from_hms_opt(hour, 0, 0)
+        } else {
+            None
+        };
     }
     let mut parts = clock.split(':');
     let mut hour: u32 = parts.next()?.trim().parse().ok()?;
@@ -277,7 +283,7 @@ mod tests {
         let candidate = Candidate::new("tomorrow at 9am", fixed(9, 0), "Europe/Warsaw");
         assert_eq!(
             candidate.display_target(),
-            "2026-06-10 09:00:00 +02:00 (Europe/Warsaw)"
+            "2026-06-10 09:00 (Europe/Warsaw +02:00)"
         );
     }
 
@@ -290,6 +296,9 @@ mod tests {
             ("today at 9 AM", 10, 9, 0),
             ("tomorrow at 9am", 11, 9, 0),
             ("June 12 at 09:00", 12, 9, 0),
+            ("11", 10, 11, 0),
+            ("11am", 10, 11, 0),
+            ("11 a.m.", 10, 11, 0),
         ] {
             let candidate = parse_direct_in(input, context_now(), New_York).unwrap();
             assert_eq!(candidate.target.day(), expected_day);


### PR DESCRIPTION
## Summary

- **Stopwatch restart key**: press `r` while the stopwatch is running (or paused) to reset it to 00:00. The key is configurable via `restart_key` in `config.toml` — supports plain chars (`r`) or modifier combos (`ctrl+r`) for users who want it harder to hit accidentally. Status bar now shows the hint.
- **Bare-hour scheduling**: `clck at 11` now works — bare integers 0–23 are accepted as 24-hour hour values, so `11` → 11:00, `14` → 14:00. Also `11 a.m.` was already supported and still works.
- **No yes/no confirmation for `clck at`**: alarm starts immediately after showing the resolved target. If the expression is invalid, it prompts to re-enter — but once a valid time is found it just goes. No more `[yes/no]:` gate.
- **Cleaner time display**: `2026-06-21 11:00 (Europe/Warsaw +02:00)` instead of `2026-06-21 11:00:00 +02:00 (Europe/Warsaw)`.

## Test plan

- [ ] `clck stopwatch` — press `r` resets to 00:00; status bar shows `r to restart`
- [ ] Set `restart_key = "ctrl+r"` in config.toml — only Ctrl+R resets, plain `r` does nothing
- [ ] `clck at 11` — resolves to 11:00 today and starts without confirmation
- [ ] `clck at 11am` / `clck at 11 a.m.` — same result
- [ ] `clck at 14:30` — still works
- [ ] `clck at invalid` — prompts to re-enter, then starts on valid input
- [ ] All 34 unit tests pass (`cargo test --lib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EnxA4oU9jFjvpDm7Vzrnmy

---
_Generated by [Claude Code](https://claude.ai/code/session_01EnxA4oU9jFjvpDm7Vzrnmy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable restart key for stopwatch (defaults to "r")
  * Hour-only time input support for alarm scheduling

* **Improvements**
  * Stopwatch UI displays the configured restart key command
  * Direct alarm scheduling streamlined—confirmation step removed

* **Changes**
  * Scheduled alarm time display format adjusted to show hours and minutes only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->